### PR TITLE
Using command + / will now use correct comments

### DIFF
--- a/settings/dustjs.cson
+++ b/settings/dustjs.cson
@@ -1,0 +1,4 @@
+'.text.html.dustjs':
+  'editor':
+    'commentStart': '{! '
+    'commentEnd': ' !}'


### PR DESCRIPTION
Adding settings folder and letting atom know what comments to use. 
This solves #1 